### PR TITLE
Only add a request handler if one defined.

### DIFF
--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -151,10 +151,13 @@ function islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_t
     'facet.mincount' => 1,
     'facet.limit' => 0,
     'facet.query' => $fq,
-    'qt' => variable_get('islandora_solr_request_handler', 'standard'),
     'hl' => 'false',
   );
-
+  $request_handler = variable_get('islandora_solr_request_handler', FALSE);
+  if ($request_handler) {
+    $params['qt'] = $request_handler;
+  }
+  
   // Set query.
   $search_term = trim($search_term);
   if ($search_term) {
@@ -217,9 +220,13 @@ function islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $
     'facet.sort' => 'index',
     'facet.mincount' => 1,
     'facet.limit' => variable_get('islandora_solr_facet_pages_facet_limit', 100000),
-    'qt' => variable_get('islandora_solr_request_handler', 'standard'),
     'hl' => 'false',
   );
+
+  $request_handler = variable_get('islandora_solr_request_handler', FALSE);
+  if ($request_handler) {
+    $facet_params['qt'] = $request_handler;
+  }
 
   // Set the facet prefix.
   if ($prefix != t('ALL')) {

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -157,7 +157,7 @@ function islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_t
   if ($request_handler) {
     $params['qt'] = $request_handler;
   }
-  
+
   // Set query.
   $search_term = trim($search_term);
   if ($search_term) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1540

# What does this Pull Request do?

Doesn't set a request handler if one is not explicitly defined in the Solr configuration through the UI.

# What's new?
Doesn't set the request handler if the "Let Solr decide" option is selected.

# How should this be tested?

Set the request handler in solr settings to "Let Solr Decide" and save your settings
Enable solr facet page module and set up a simple facet page
Browse to your facet page, you will see a Solr 400 error.
Open pulling in this change this will no longer occur.

# Interested parties
@Islandora/7-x-1-x-committers

