### PR TITLE
7.x 1889

### DIFF
--- a/islandora_solr_facet_pages.admin.inc
+++ b/islandora_solr_facet_pages.admin.inc
@@ -118,8 +118,8 @@ function islandora_solr_facet_pages_admin_settings($form, &$form_state) {
   $form['facet_pages']['islandora_solr_facet_pages_lucene_charset_default'] = array(
     '#type' => 'textfield',
     '#title' => t('Default characters to escape'),
-    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_charset_default', "+,-,&&,||,!,(,),{,},[,],^,~,:"),
-    '#description' => t("The default character set to escape when found in search terms, comma seperated list of values. Defaults to '+,-,&&,||,!,(,),{,},[,],^,~,:'"),
+    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_charset_default', "+,-,&&,||,!,(,),{,},[,],^,~,:,\""),
+    '#description' => t("The default character set to escape when found in search terms, comma seperated list of values. Defaults to '+,-,&&,||,!,(,),{,},[,],^,~,:,\"'"),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_solr_facet_pages_lucene_syntax_escape"]' => array('checked' => TRUE),

--- a/islandora_solr_facet_pages.admin.inc
+++ b/islandora_solr_facet_pages.admin.inc
@@ -107,7 +107,7 @@ function islandora_solr_facet_pages_admin_settings($form, &$form_state) {
   $form['facet_pages']['islandora_solr_facet_pages_lucene_syntax_escape'] = array(
     '#title' => t('Allow the use of lucene syntax string escaping on search terms'),
     '#type' => 'checkbox',
-    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_syntax_escape', TRUE),
+    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_syntax_escape', FALSE),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_solr_facet_pages_search_form"]' => array('checked' => TRUE),
@@ -115,11 +115,16 @@ function islandora_solr_facet_pages_admin_settings($form, &$form_state) {
     ),
   );
 
-  $form['facet_pages']['islandora_solr_facet_pages_lucene_charset_default'] = array(
+  $form['facet_pages']['islandora_solr_facet_pages_lucene_regex_default'] = array(
     '#type' => 'textfield',
-    '#title' => t('Default characters to escape'),
-    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_charset_default', "+,-,&&,||,!,(,),{,},[,],^,~,:,\""),
-    '#description' => t("The default character set to escape when found in search terms, comma seperated list of values. Defaults to '+,-,&&,||,!,(,),{,},[,],^,~,:,\"'"),
+    '#title' => t('Default regular expression evaluated on search term'),
+    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX),
+    '#description' => t(
+      "The default regular expression, used to escape characters when found in search terms. Defaults to @regex",
+      array(
+        '@regex' => ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX,
+      )
+    ),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_solr_facet_pages_lucene_syntax_escape"]' => array('checked' => TRUE),
@@ -235,7 +240,7 @@ function islandora_solr_facet_pages_admin_settings_submit($form, &$form_state) {
       variable_set('islandora_solr_facet_pages_facet_limit', $form_state['values']['islandora_solr_facet_pages_facet_limit']);
       variable_set('islandora_solr_facet_pages_search_form', $form_state['values']['islandora_solr_facet_pages_search_form']);
 
-      variable_set('islandora_solr_facet_pages_lucene_charset_default', $form_state['values']['islandora_solr_facet_pages_lucene_charset_default']);
+      variable_set('islandora_solr_facet_pages_lucene_charset_default', $form_state['values']['islandora_solr_facet_pages_lucene_regex_default']);
       variable_set('islandora_solr_facet_pages_lucene_syntax_escape', $form_state['values']['islandora_solr_facet_pages_lucene_syntax_escape']);
 
       drupal_set_message(t('The configuration options have been saved.'));

--- a/islandora_solr_facet_pages.admin.inc
+++ b/islandora_solr_facet_pages.admin.inc
@@ -118,11 +118,11 @@ function islandora_solr_facet_pages_admin_settings($form, &$form_state) {
   $form['facet_pages']['islandora_solr_facet_pages_lucene_regex_default'] = array(
     '#type' => 'textfield',
     '#title' => t('Default regular expression evaluated on search term'),
-    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX),
+    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT),
     '#description' => t(
       "The default regular expression, used to escape characters when found in search terms. Defaults to @regex",
       array(
-        '@regex' => ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX,
+        '@regex' => ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT,
       )
     ),
     '#states' => array(

--- a/islandora_solr_facet_pages.admin.inc
+++ b/islandora_solr_facet_pages.admin.inc
@@ -115,14 +115,14 @@ function islandora_solr_facet_pages_admin_settings($form, &$form_state) {
     ),
   );
 
-  $form['facet_pages']['islandora_solr_facet_pages_lucene_regex_default'] = array(
+  $form['facet_pages']['islandora_solr_facet_pages_lucene_escape_regex'] = array(
     '#type' => 'textfield',
     '#title' => t('Default regular expression evaluated on search term'),
-    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX),
+    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_escape_regex', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT),
     '#description' => t(
       "The default regular expression, used to escape characters when found in search terms. Defaults to @regex",
       array(
-        '@regex' => ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX,
+        '@regex' => ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT,
       )
     ),
     '#states' => array(
@@ -240,7 +240,7 @@ function islandora_solr_facet_pages_admin_settings_submit($form, &$form_state) {
       variable_set('islandora_solr_facet_pages_facet_limit', $form_state['values']['islandora_solr_facet_pages_facet_limit']);
       variable_set('islandora_solr_facet_pages_search_form', $form_state['values']['islandora_solr_facet_pages_search_form']);
 
-      variable_set('islandora_solr_facet_pages_lucene_regex_default', $form_state['values']['islandora_solr_facet_pages_lucene_regex_default']);
+      variable_set('islandora_solr_facet_pages_lucene_escape_regex', $form_state['values']['islandora_solr_facet_pages_lucene_escape_regex']);
       variable_set('islandora_solr_facet_pages_lucene_syntax_escape', $form_state['values']['islandora_solr_facet_pages_lucene_syntax_escape']);
 
       drupal_set_message(t('The configuration options have been saved.'));

--- a/islandora_solr_facet_pages.admin.inc
+++ b/islandora_solr_facet_pages.admin.inc
@@ -123,7 +123,6 @@ function islandora_solr_facet_pages_admin_settings($form, &$form_state) {
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_solr_facet_pages_lucene_syntax_escape"]' => array('checked' => TRUE),
-        'or',
         ':input[name="islandora_solr_facet_pages_search_form"]' => array('checked' => TRUE),
       ),
     ),

--- a/islandora_solr_facet_pages.admin.inc
+++ b/islandora_solr_facet_pages.admin.inc
@@ -240,7 +240,7 @@ function islandora_solr_facet_pages_admin_settings_submit($form, &$form_state) {
       variable_set('islandora_solr_facet_pages_facet_limit', $form_state['values']['islandora_solr_facet_pages_facet_limit']);
       variable_set('islandora_solr_facet_pages_search_form', $form_state['values']['islandora_solr_facet_pages_search_form']);
 
-      variable_set('islandora_solr_facet_pages_lucene_charset_default', $form_state['values']['islandora_solr_facet_pages_lucene_regex_default']);
+      variable_set('islandora_solr_facet_pages_lucene_regex_default', $form_state['values']['islandora_solr_facet_pages_lucene_regex_default']);
       variable_set('islandora_solr_facet_pages_lucene_syntax_escape', $form_state['values']['islandora_solr_facet_pages_lucene_syntax_escape']);
 
       drupal_set_message(t('The configuration options have been saved.'));

--- a/islandora_solr_facet_pages.admin.inc
+++ b/islandora_solr_facet_pages.admin.inc
@@ -104,6 +104,31 @@ function islandora_solr_facet_pages_admin_settings($form, &$form_state) {
     '#description' => t('Display a search form on the facet page.'),
   );
 
+  $form['facet_pages']['islandora_solr_facet_pages_lucene_syntax_escape'] = array(
+    '#title' => t('Allow the use of lucene syntax string escaping on search terms'),
+    '#type' => 'checkbox',
+    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_syntax_escape', TRUE),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_solr_facet_pages_search_form"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+
+  $form['facet_pages']['islandora_solr_facet_pages_lucene_charset_default'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Default characters to escape'),
+    '#default_value' => variable_get('islandora_solr_facet_pages_lucene_charset_default', "+,-,&&,||,!,(,),{,},[,],^,~,:"),
+    '#description' => t("The default character set to escape when found in search terms, comma seperated list of values. Defaults to '+,-,&&,||,!,(,),{,},[,],^,~,:'"),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_solr_facet_pages_lucene_syntax_escape"]' => array('checked' => TRUE),
+        'or',
+        ':input[name="islandora_solr_facet_pages_search_form"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+
   $form['buttons']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
@@ -210,6 +235,9 @@ function islandora_solr_facet_pages_admin_settings_submit($form, &$form_state) {
       variable_set('islandora_solr_facet_pages_limit', trim($form_state['values']['islandora_solr_facet_pages_limit']));
       variable_set('islandora_solr_facet_pages_facet_limit', $form_state['values']['islandora_solr_facet_pages_facet_limit']);
       variable_set('islandora_solr_facet_pages_search_form', $form_state['values']['islandora_solr_facet_pages_search_form']);
+
+      variable_set('islandora_solr_facet_pages_lucene_charset_default', $form_state['values']['islandora_solr_facet_pages_lucene_charset_default']);
+      variable_set('islandora_solr_facet_pages_lucene_syntax_escape', $form_state['values']['islandora_solr_facet_pages_lucene_syntax_escape']);
 
       drupal_set_message(t('The configuration options have been saved.'));
       break;

--- a/islandora_solr_facet_pages.install
+++ b/islandora_solr_facet_pages.install
@@ -13,7 +13,7 @@ function islandora_solr_facet_pages_uninstall() {
   $variables = array(
     'islandora_solr_facet_pages_fields_data',
     'islandora_solr_facet_pages_lucene_syntax_escape',
-    'islandora_solr_facet_pages_lucene_regex_default',
+    'islandora_solr_facet_pages_lucene_escape_regex',
     'islandora_solr_facet_pages_limit',
     'islandora_solr_facet_pages_facet_limit',
     'islandora_solr_facet_pages_search_form',

--- a/islandora_solr_facet_pages.install
+++ b/islandora_solr_facet_pages.install
@@ -12,6 +12,8 @@ function islandora_solr_facet_pages_uninstall() {
   // Remove variables.
   $variables = array(
     'islandora_solr_facet_pages_fields_data',
+    'islandora_solr_facet_pages_lucene_syntax_escape',
+    'islandora_solr_facet_pages_lucene_charset_default',
     'islandora_solr_facet_pages_limit',
     'islandora_solr_facet_pages_facet_limit',
     'islandora_solr_facet_pages_search_form',

--- a/islandora_solr_facet_pages.install
+++ b/islandora_solr_facet_pages.install
@@ -13,7 +13,7 @@ function islandora_solr_facet_pages_uninstall() {
   $variables = array(
     'islandora_solr_facet_pages_fields_data',
     'islandora_solr_facet_pages_lucene_syntax_escape',
-    'islandora_solr_facet_pages_lucene_charset_default',
+    'islandora_solr_facet_pages_lucene_regex_default',
     'islandora_solr_facet_pages_limit',
     'islandora_solr_facet_pages_facet_limit',
     'islandora_solr_facet_pages_search_form',

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -325,7 +325,7 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   // Create an escaped version of the facet search term, for use with
   // the queries run below. Preserve the origional '$search_term' for
   // use with the form's 'search_term' value below.
-  $search_term_escape = islandora_solr_facet_escape($search_term);
+  $search_term_escape = islandora_solr_lesser_escape($search_term);
 
   // Render letters.
   $letterer_arr = islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_term_escape);

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -332,12 +332,12 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   // We do this to preserve the original value of the search term, so that
   // subsequent calls to drupal_get_form() are prepopulated with the user
   // input text, and not the escaped string.
-  $search_term_escape = $search_term;
-  if (variable_get('islandora_solr_facet_pages_search_form', TRUE) &&
-    variable_get('islandora_solr_facet_pages_lucene_syntax_escape', FALSE)) {
-    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX);
-    $search_term_escape = islandora_solr_facet_query_escape($search_term, explode(',', $escape_charset));
-  }
+  $show_form = variable_get('islandora_solr_facet_pages_search_form', TRUE);
+  $escape_lucene = variable_get('islandora_solr_facet_pages_lucene_syntax_escape', FALSE);
+
+  $search_term_escape = ($show_form && $escape_lucene) ?
+    islandora_solr_facet_query_escape($search_term, variable_get('islandora_solr_facet_pages_lucene_regex', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT)) :
+    islandora_solr_lesser_escape($search_term);
 
   // Render letters.
   $letterer_arr = islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_term_escape);

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -332,7 +332,7 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   $search_term_escape = $search_term;
   if (variable_get('islandora_solr_facet_pages_search_form', TRUE) &&
     variable_get('islandora_solr_facet_pages_lucene_syntax_escape', TRUE)) {
-    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', '+,-,&&,||,!,(,),{,},[,],^,",~,*,?,:');
+    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', '+,-,&&,||,!,(,),{,},[,],^,",~,*,?,:,\"');
     $search_term_escape = islandora_solr_facet_query_escape($search_term, explode(',', $escape_charset));
   }
 

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -137,6 +137,7 @@ function islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_t
   $solr_build = new IslandoraSolrQueryProcessor();
   $fq = array();
   $fq_map = array();
+
   foreach (range('A', 'Z') as $letter) {
     $value = "$solr_field:($letter* OR " . strtolower($letter) . "*)";
     $fq_map[$value] = $letter;
@@ -178,7 +179,6 @@ function islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_t
     $facet_queries = new stdClass();
     drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
   }
-
   return array(
     'facet_queries' => $facet_queries,
     'fq_map' => $fq_map,
@@ -206,13 +206,13 @@ function islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $
   $solr_build = new IslandoraSolrQueryProcessor();
   // Get the actual results.
   $search_term = trim($search_term);
+
   if ($search_term) {
-    $query = "$solr_field:($search_term)";
+    $query = "$solr_field:$search_term";
   }
   else {
     $query = "$solr_field:[* TO *]";
   }
-
   // Set facet parameters.
   $facet_params = array(
     'facet' => 'true',
@@ -235,7 +235,9 @@ function islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $
   $solr_build->buildQuery($query, $facet_params);
   $solr_query = ($solr_build->internalSolrQuery) ? $solr_build->internalSolrQuery : $solr_build->solrQuery;
   // Because the IslandoraSolrQueryProcessor stomps on our facet information.
+
   $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $facet_params);
+
   try {
     $solr_build->executeQuery();
     $fields = (array) $solr_build->islandoraSolrResult['facet_counts']['facet_fields'][$solr_field];
@@ -320,8 +322,13 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   $parsed_url = parse_url(variable_get('islandora_solr_url', 'http://localhost:8080/solr'));
   $solr = new Apache_Solr_Service($parsed_url['host'], $parsed_url['port'], $parsed_url['path']);
 
+  // Create an escaped version of the facet search term, for use with
+  // the queries run below. Preserve the origional '$search_term' for
+  // use with the form's 'search_term' value below.
+  $search_term_escape = islandora_solr_facet_escape($search_term);
+
   // Render letters.
-  $letterer_arr = islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_term);
+  $letterer_arr = islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_term_escape);
   $letterer = theme('islandora_solr_facet_pages_letterer', array(
     'facet_queries' => $letterer_arr['facet_queries'],
     'fq_map' => $letterer_arr['fq_map'],
@@ -330,10 +337,11 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   ));
 
   // Collect results.
-  $result_fields = islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $search_term);
+  $result_fields = islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $search_term_escape);
   // Collect results with lowercase.
   $prefix_lower = strtolower($prefix);
-  $result_fields_lower = islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix_lower, $search_term);
+  $result_fields_lower = islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix_lower, $search_term_escape);
+
   // Merge uppercase with lowercase.
   $result_fields = $result_fields + $result_fields_lower;
 

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -234,8 +234,8 @@ function islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $
   }
   $solr_build->buildQuery($query, $facet_params);
   $solr_query = ($solr_build->internalSolrQuery) ? $solr_build->internalSolrQuery : $solr_build->solrQuery;
+  
   // Because the IslandoraSolrQueryProcessor stomps on our facet information.
-
   $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $facet_params);
 
   try {
@@ -322,10 +322,21 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   $parsed_url = parse_url(variable_get('islandora_solr_url', 'http://localhost:8080/solr'));
   $solr = new Apache_Solr_Service($parsed_url['host'], $parsed_url['port'], $parsed_url['path']);
 
-  // Create an escaped version of the facet search term, for use with
-  // the queries run below. Preserve the origional '$search_term' for
-  // use with the form's 'search_term' value below.
-  $search_term_escape = islandora_solr_lesser_escape($search_term);
+  // Create an escaped variable for the facet search term, for use with
+  // the following two functions below:
+  //
+  // islandora_solr_facet_pages_build_letterer()
+  // islandora_solr_facet_pages_build_results()
+  //
+  // We do this to preserve the original value of the search term, so that
+  // subsequent calls to drupal_get_form() are prepopulated with the user
+  // input text, and not the escaped string.
+  $search_term_escape = $search_term;
+  if (variable_get('islandora_solr_facet_pages_search_form', FALSE) &&
+    variable_get('islandora_solr_facet_pages_lucene_syntax_escape', TRUE)) {
+    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', "+, -, &&, ||, !, (, ), {, }, [, ], ^, ~, :");
+    $search_term_escape = islandora_solr_facet_query_escape($search_term, explode(',', $escape_charset));
+  }
 
   // Render letters.
   $letterer_arr = islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_term_escape);

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -137,7 +137,6 @@ function islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_t
   $solr_build = new IslandoraSolrQueryProcessor();
   $fq = array();
   $fq_map = array();
-
   foreach (range('A', 'Z') as $letter) {
     $value = "$solr_field:($letter* OR " . strtolower($letter) . "*)";
     $fq_map[$value] = $letter;
@@ -179,6 +178,7 @@ function islandora_solr_facet_pages_build_letterer($solr, $solr_field, $search_t
     $facet_queries = new stdClass();
     drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
   }
+
   return array(
     'facet_queries' => $facet_queries,
     'fq_map' => $fq_map,
@@ -206,13 +206,13 @@ function islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $
   $solr_build = new IslandoraSolrQueryProcessor();
   // Get the actual results.
   $search_term = trim($search_term);
-
   if ($search_term) {
     $query = "$solr_field:($search_term)";
   }
   else {
     $query = "$solr_field:[* TO *]";
   }
+
   // Set facet parameters.
   $facet_params = array(
     'facet' => 'true',
@@ -234,10 +234,8 @@ function islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $
   }
   $solr_build->buildQuery($query, $facet_params);
   $solr_query = ($solr_build->internalSolrQuery) ? $solr_build->internalSolrQuery : $solr_build->solrQuery;
-  
   // Because the IslandoraSolrQueryProcessor stomps on our facet information.
   $solr_build->solrParams = array_replace_recursive($solr_build->solrParams, $facet_params);
-
   try {
     $solr_build->executeQuery();
     $fields = (array) $solr_build->islandoraSolrResult['facet_counts']['facet_fields'][$solr_field];
@@ -334,7 +332,7 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   $search_term_escape = $search_term;
   if (variable_get('islandora_solr_facet_pages_search_form', FALSE) &&
     variable_get('islandora_solr_facet_pages_lucene_syntax_escape', TRUE)) {
-    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', "+, -, &&, ||, !, (, ), {, }, [, ], ^, ~, :");
+    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', "+,-,&&,||,!,(,),{,},[,],^,~,:");
     $search_term_escape = islandora_solr_facet_query_escape($search_term, explode(',', $escape_charset));
   }
 

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -208,7 +208,7 @@ function islandora_solr_facet_pages_build_results($solr, $solr_field, $prefix, $
   $search_term = trim($search_term);
 
   if ($search_term) {
-    $query = "$solr_field:$search_term";
+    $query = "$solr_field:($search_term)";
   }
   else {
     $query = "$solr_field:[* TO *]";

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -330,9 +330,9 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   // subsequent calls to drupal_get_form() are prepopulated with the user
   // input text, and not the escaped string.
   $search_term_escape = $search_term;
-  if (variable_get('islandora_solr_facet_pages_search_form', FALSE) &&
+  if (variable_get('islandora_solr_facet_pages_search_form', TRUE) &&
     variable_get('islandora_solr_facet_pages_lucene_syntax_escape', TRUE)) {
-    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', "+,-,&&,||,!,(,),{,},[,],^,~,:");
+    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', '+,-,&&,||,!,(,),{,},[,],^,",~,*,?,:');
     $search_term_escape = islandora_solr_facet_query_escape($search_term, explode(',', $escape_charset));
   }
 

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -332,7 +332,7 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   $search_term_escape = $search_term;
   if (variable_get('islandora_solr_facet_pages_search_form', TRUE) &&
     variable_get('islandora_solr_facet_pages_lucene_syntax_escape', FALSE)) {
-    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX);
+    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT);
     $search_term_escape = islandora_solr_facet_query_escape($search_term, explode(',', $escape_charset));
   }
 

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -296,7 +296,7 @@ function islandora_solr_facet_pages_pager($result_fields = array()) {
  */
 function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $search_term = NULL) {
   module_load_include('inc', 'islandora_solr', 'includes/utilities');
-  $search_term = islandora_solr_replace_slashes($search_term);
+  $search_term = islandora_solr_restore_slashes($search_term);
 
   // Get available fields from variable.
   $fields = variable_get('islandora_solr_facet_pages_fields_data', array());
@@ -499,6 +499,7 @@ function islandora_solr_facet_pages_search_form(array $form, array &$form_state,
  *   The Drupal form state.
  */
 function islandora_solr_facet_pages_search_form_submit(array $form, array &$form_state) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
   $form_state['redirect'] = implode('/', array(
     'browse',
     $form_state['storage']['vars']['path'],

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -295,6 +295,9 @@ function islandora_solr_facet_pages_pager($result_fields = array()) {
  *   Rendered page including letter pager, numerical pager and search results.
  */
 function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $search_term = NULL) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+  $search_term = islandora_solr_replace_slashes($search_term);
+
   // Get available fields from variable.
   $fields = variable_get('islandora_solr_facet_pages_fields_data', array());
 
@@ -496,5 +499,10 @@ function islandora_solr_facet_pages_search_form(array $form, array &$form_state,
  *   The Drupal form state.
  */
 function islandora_solr_facet_pages_search_form_submit(array $form, array &$form_state) {
-  drupal_goto("browse/{$form_state['storage']['vars']['path']}/{$form_state['storage']['vars']['prefix']}/{$form_state['values']['search_term']}");
+  $form_state['redirect'] = implode('/', array(
+    'browse',
+    $form_state['storage']['vars']['path'],
+    $form_state['storage']['vars']['prefix'],
+    islandora_solr_replace_slashes($form_state['values']['search_term']),
+  ));
 }

--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -331,8 +331,8 @@ function islandora_solr_facet_pages_callback($path = NULL, $prefix = NULL, $sear
   // input text, and not the escaped string.
   $search_term_escape = $search_term;
   if (variable_get('islandora_solr_facet_pages_search_form', TRUE) &&
-    variable_get('islandora_solr_facet_pages_lucene_syntax_escape', TRUE)) {
-    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_charset_default', '+,-,&&,||,!,(,),{,},[,],^,",~,*,?,:,\"');
+    variable_get('islandora_solr_facet_pages_lucene_syntax_escape', FALSE)) {
+    $escape_charset = variable_get('islandora_solr_facet_pages_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX);
     $search_term_escape = islandora_solr_facet_query_escape($search_term, explode(',', $escape_charset));
   }
 


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1889)

# What does this Pull Request do?
When preforming a facet search on the Islandora SOLR facet pages page (ex: {site}/browse/{title}) or with the advanced search block, special characters (such as '[' or ']') will throw an 'Error searching Solr index "400" Status: Bad Request'.

# What's new?
Implements the [islandora_solr_facet_escape()|https://github.com/Islandora/islandora_solr_search/blob/7.x/includes/utilities.inc#L165] utility function on the search term prior to query execution.

# How should this be tested?
- Navigate to a configured SOLR facet page (ex: {site}/browse/title) with the facet page search enabled.
- Preform a search query with an invalid character (such as 'Lobster[' or 'lobster{{}'). Results pages should not throw a 400 error.

# Steps to reproduce
- Navigate to a configured SOLR facet page (ex: {site}/browse/title) with the facet page search enabled, or the advanced search block
- Preform a search query with an invalid character (such as 'Lobster[' or 'lobster{{}'). Results pages will throw an error.

# Interested parties
@Islandora/7-x-1-x-committers 
