### PR TITLE
Trimming search terms in islandora_solr_facet_pages

### DIFF
--- a/islandora_solr_facet_pages.module
+++ b/islandora_solr_facet_pages.module
@@ -504,6 +504,6 @@ function islandora_solr_facet_pages_search_form_submit(array $form, array &$form
     'browse',
     $form_state['storage']['vars']['path'],
     $form_state['storage']['vars']['prefix'],
-    islandora_solr_replace_slashes($form_state['values']['search_term']),
+    islandora_solr_replace_slashes(trim($form_state['values']['search_term'])),
   ));
 }


### PR DESCRIPTION
# Jira Ticket: https://jira.duraspace.org/browse/ISLANDORA-1996

# What does this Pull Request do?

It was discovered during testing that when conducting a solr_facet_pages search that when the user typed a space it would create an error. 

# What's new?

The trim function is used on the search term in islandora_solr_facet_pages_search_form_submit(). 

# How should this be tested?

Create a facet search page and search for a "space" and submit the form. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
